### PR TITLE
Add bitpacking for patterns

### DIFF
--- a/src/ascii_bit_set.rs
+++ b/src/ascii_bit_set.rs
@@ -1,0 +1,68 @@
+/**
+    Lower-case ASCII bit-set, to quickly check if letter i
+**/
+#[derive(Default, Copy, Clone)]
+pub struct AsciiBitSet {
+    set: u32,
+}
+
+impl AsciiBitSet {
+    pub fn set_letter(&mut self, l: u8) {
+        self.set |= 1 << l
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut set = Self::default();
+        for b in bytes {
+            set.set |= 1 << b;
+        }
+
+        set
+    }
+
+    #[inline]
+    pub fn has_letter(&self, letter: u8) -> bool {
+        (self.set >> letter) & 1 == 1
+    }
+
+    #[inline]
+    pub fn intersect(&self, set: &Self) -> bool {
+        self.set & set.set != 0
+    }
+}
+
+mod tests {
+    use crate::AsciiBitSet;
+
+    #[test]
+    fn test_from_bytes() {
+        let s = AsciiBitSet::from_bytes("abcde".as_bytes());
+        assert_eq!(s.set, 0b11111);
+
+        let s = AsciiBitSet::from_bytes("zyxwv".as_bytes());
+        assert_eq!(s.set, 0b0011_1110_0000_0000_0000_0000_0000);
+
+        let s = AsciiBitSet::from_bytes("abcdefghijklmnopqrstuvwxyz".as_bytes());
+        assert_eq!(s.set, 0b0011_1111_1111_1111_1111_1111_1111);
+    }
+
+    #[test]
+    fn test_has_letter() {
+        let mut s = AsciiBitSet::default();
+        s.set_letter(b'a');
+        s.set_letter(b'z');
+        s.set_letter(b'k');
+
+        assert!(s.has_letter(b'a'));
+        assert!(s.has_letter(b'z'));
+        assert!(s.has_letter(b'k'));
+    }
+
+    #[test]
+    fn test_intersect() {
+        let l = AsciiBitSet::from_bytes("abcde".as_bytes());
+        let r = AsciiBitSet::from_bytes("bdz".as_bytes());
+
+        assert!(l.intersect(&r));
+    }
+}

--- a/src/fivegram.rs
+++ b/src/fivegram.rs
@@ -1,0 +1,86 @@
+/**
+    Bit-packed 5-letter a-z ASCII word:
+
+    empty = 0b00000
+    a     = 0b00001
+    ...
+    z     = 0b11010
+**/
+#[derive(Default, Copy, Clone)]
+pub struct Fivegram {
+    word: u32
+}
+
+impl Fivegram {
+    pub fn set_letter(&mut self, l: u8, pos: usize) {
+        self.word |= ((l + 1) as u32) << (pos * 5)
+    }
+
+    #[inline]
+    pub fn has_letter(&self, l: u8, pos: usize) -> bool {
+        (self.word >> (pos * 5)) & 0b11111 == (l + 1) as u32
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut res = Self::default();
+        for (i, b) in bytes.iter().enumerate() {
+            res.set_letter(*b, i);
+        }
+
+        res
+    }
+
+    #[inline]
+    pub fn partial_match(&self, pattern: &Self) -> bool {
+        self.word & pattern.word == pattern.word
+    }
+}
+
+mod tests {
+    use crate::Fivegram;
+
+    #[test]
+    fn test_from_bytes() {
+        let fg = Fivegram::from_bytes("abcde".as_bytes());
+
+        assert_eq!(fg.word,
+            0b00_00000_00101_00100_00011_00010_00001);
+    }
+
+    #[test]
+    fn test_has_letter() {
+        let fg = Fivegram::from_bytes("abcde".as_bytes());
+
+        assert!(fg.has_letter(b'a', 0));
+        assert!(fg.has_letter(b'b', 1));
+        assert!(fg.has_letter(b'c', 2));
+        assert!(fg.has_letter(b'd', 3));
+        assert!(fg.has_letter(b'e', 4));
+    }
+
+    #[test]
+    fn test_matches_full() {
+        let l = Fivegram::from_bytes("abcde".as_bytes());
+        let r = Fivegram::from_bytes("abcde".as_bytes());
+
+        assert!(l.partial_match(&r));
+    }
+
+    #[test]
+    fn test_matches_prefix() {
+        let l = Fivegram::from_bytes("abcde".as_bytes());
+        let r = Fivegram::from_bytes("abc".as_bytes());
+
+        assert!(l.partial_match(&r));
+    }
+
+    #[test]
+    fn test_matches_with_holes() {
+        let l = Fivegram::from_bytes("abcde".as_bytes());
+        let mut r = Fivegram::default();
+        r.set_letter(b'b', 1);
+        r.set_letter(b'd', 3);
+
+        assert!(l.partial_match(&r));
+    }
+}


### PR DESCRIPTION
Tests will fail to pass as they assume that values are passed without `- b'a'`